### PR TITLE
Fix kulala parser installation

### DIFF
--- a/nvim/plugin/kulala-no-parsers.lua
+++ b/nvim/plugin/kulala-no-parsers.lua
@@ -1,0 +1,20 @@
+-- Disable automatic Treesitter parser installation for kulala.nvim
+-- This replaces the internal set_kulala_parser function with a no-op
+
+local ok, config = pcall(require, "kulala.config")
+if not ok then
+  return
+end
+
+local i = 1
+while true do
+  local name = debug.getupvalue(config.setup, i)
+  if not name then
+    break
+  end
+  if name == "set_kulala_parser" then
+    debug.setupvalue(config.setup, i, function() end)
+    break
+  end
+  i = i + 1
+end


### PR DESCRIPTION
## Summary
- disable kulala.nvim's automatic parser installation by overriding `set_kulala_parser`

## Testing
- `lua test.lua`

------
https://chatgpt.com/codex/tasks/task_e_6886a90bb104832992441737a9909176