### PR TITLE
Fix kulala parser build

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -70,3 +70,7 @@ in {
 
 With the parser built during the Nix build, Neovim no longer tries to compile
 it at runtime and the read‑only store is not an issue.
+
+This repository includes the above setup.  The Neovim wrapper exposes the parser
+path via the `KULALA_HTTP_PARSER` environment variable and
+`nvim/plugin/treesitter.lua` registers the parser if that variable is present.

--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -29,8 +29,9 @@ with lib;
     withPython3 ? true, # Build Neovim with Python 3 support?
     withRuby ? false, # Build Neovim with Ruby support?
     withNodeJs ? true, # Build Neovim with NodeJS support?
-    withSqlite ? true, # Add sqlite? This is a dependency for some plugins
-    # You probably don't want to create vi or vim aliases
+  withSqlite ? true, # Add sqlite? This is a dependency for some plugins
+  kulalaParser ? null, # prebuilt kulala_http tree-sitter grammar
+  # You probably don't want to create vi or vim aliases
     # if the appName is something different than "nvim"
     # Add a "vi" binary to the build output as an alias?
     viAlias ? appName == null || appName == "nvim",
@@ -168,6 +169,8 @@ with lib;
       # Set the LIBSQLITE environment variable if sqlite is enabled
       ++ (optional withSqlite
         ''--set LIBSQLITE "${pkgs.sqlite.out}/lib/libsqlite3.so"'')
+      ++ (optional (kulalaParser != null)
+        ''--set KULALA_HTTP_PARSER "${kulalaParser}"'')
     );
 
     luaPackages = neovim-unwrapped.lua.pkgs;

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -17,6 +17,20 @@ with final.pkgs.lib; let
   # This is the helper function that builds the Neovim derivation.
   mkNeovim = pkgs.callPackage ./mkNeovim.nix {inherit pkgs-wrapNeovim;};
 
+  # Pre-build the kulala_http tree-sitter grammar so nvim doesn't try
+  # to compile it in the read-only store
+  treesitter-kulala-http = pkgs.tree-sitter.buildGrammar {
+    language = "kulala_http";
+    version = "5.3.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "mistweaverco";
+      repo = "kulala.nvim";
+      rev = "902fc21e8a3fee7ccace37784879327baa6d1ece";
+      hash = "sha256-whQpwZMEvD62lgCrnNryrEvfSwLJJ+IqVCywTq78Vf8=";
+    };
+    location = "lua/tree-sitter";
+  };
+
   # Replace plugins with user's custom plugins and configuration.
   all-plugins = with pkgs.vimPlugins; [
     telescope-zoxide
@@ -189,10 +203,13 @@ in {
   nvim-pkg = mkNeovim {
     plugins = all-plugins;
     inherit extraPackages;
+    kulalaParser = treesitter-kulala-http;
   };
 
   # This can be symlinked in the devShell's shellHook
   nvim-luarc-json = final.mk-luarc-json {
     plugins = all-plugins;
   };
+
+  treesitter-kulala-http = treesitter-kulala-http;
 }

--- a/nvim/plugin/treesitter.lua
+++ b/nvim/plugin/treesitter.lua
@@ -3,6 +3,21 @@
 -- Define the directory for storing Treesitter parsers (still needed by nvim-treesitter itself)
 local parser_install_dir = vim.fn.stdpath("data") .. "/treesitter-parsers"
 
+-- If the KULALA_HTTP_PARSER environment variable is set, register the
+-- prebuilt parser directly with nvim-treesitter.  This avoids attempts to
+-- compile the parser inside the read-only Nix store.
+local kulala_parser = os.getenv("KULALA_HTTP_PARSER")
+if kulala_parser then
+  local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+  parser_config.kulala_http = {
+    install_info = {
+      url = kulala_parser,
+      files = {"src/parser.c"},
+    },
+    filetype = "kulala_http",
+  }
+end
+
 -- Configure nvim-treesitter
 require("nvim-treesitter.configs").setup({
 	modules = {},


### PR DESCRIPTION
## Summary
- pre-build kulala_http parser and export as `treesitter-kulala-http`
- pass parser path to the Neovim wrapper
- register prebuilt parser in `nvim/plugin/treesitter.lua`
- document how this works

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886fab584c4832980a64d812592b0fb