### PR TITLE
feat(nvim): replace jdtls with nvim-java

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 #
 #run the following script
 #
-# Java support is provided by nvim-java with Lombok and Spring Boot tools; no manual jdtls setup needed.
+# Java support is provided by nvim-java with Lombok; no manual jdtls setup needed.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,7 @@
 #
 #run the following script
 #
-#cp -r /nix/store/301k2jhjanl6rr96b9yy9qzcrhjbwgmz-jdt-language-server-1.36.0/share/java/jdtls/config_linux /home/hubert/.jdtls_config
-#chmod -R u+w /home/hubert/.jdtls_config
-
-
+# Java support is provided by nvim-java with Lombok, no manual jdtls setup needed.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 #
 #run the following script
 #
-# Java support is provided by nvim-java with Lombok; no manual jdtls setup needed.
+# Java support is provided by nvim-java with Lombok and Spring Boot tools; no manual jdtls setup needed.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 #
 #run the following script
 #
-# Java support is provided by nvim-java with Lombok, no manual jdtls setup needed.
+# Java support is provided by nvim-java with Lombok and Spring Boot tools; no manual jdtls setup needed.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,10 @@
       url = "github:eldritch-theme/eldritch.nvim";
       flake = false;
     };
+    nvim-java = {
+      url = "github:nvim-java/nvim-java";
+      flake = false;
+    };
     # Consider adding your neovim overlay source as an input if it's external
     # neovim-overlay-src.url = "github:your/neovim-overlay-repo"; # Example
   };

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,6 @@
       url = "github:eldritch-theme/eldritch.nvim";
       flake = false;
     };
-    nvim-java = {
-      url = "github:nvim-java/nvim-java";
-      flake = false;
-    };
     # Consider adding your neovim overlay source as an input if it's external
     # neovim-overlay-src.url = "github:your/neovim-overlay-repo"; # Example
   };

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -11,6 +11,7 @@ with final.pkgs.lib; let
     };
 
   eldritch-nvim = mkNvimPlugin inputs.eldritch-nvim "eldritch-nvim";
+  nvim-java = mkNvimPlugin inputs.nvim-java "nvim-java";
 
   # Make sure we use the pinned nixpkgs instance for wrapNeovimUnstable,
   # otherwise it could have an incompatible signature when applying this overlay.
@@ -130,7 +131,7 @@ with final.pkgs.lib; let
       plugin = typescript-tools-nvim; # Enhanced TypeScript support
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
-    nvim-jdtls # Java language server
+    { plugin = nvim-java; } # Java language support
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -131,7 +131,6 @@ with final.pkgs.lib; let
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
     { plugin = nvim-java; } # Java language support
-    { plugin = spring-boot-nvim; } # Spring Boot tools for nvim-java
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -11,7 +11,6 @@ with final.pkgs.lib; let
     };
 
   eldritch-nvim = mkNvimPlugin inputs.eldritch-nvim "eldritch-nvim";
-  nvim-java = mkNvimPlugin inputs.nvim-java "nvim-java";
 
   # Make sure we use the pinned nixpkgs instance for wrapNeovimUnstable,
   # otherwise it could have an incompatible signature when applying this overlay.

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -131,6 +131,7 @@ with final.pkgs.lib; let
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
     { plugin = nvim-java; } # Java language support
+    { plugin = spring-boot-nvim; } # Spring Boot tools for nvim-java
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -12,6 +12,14 @@ with final.pkgs.lib; let
 
   eldritch-nvim = mkNvimPlugin inputs.eldritch-nvim "eldritch-nvim";
 
+  spring-boot-nvim =
+    mkNvimPlugin
+      (builtins.fetchGit {
+        url = "https://github.com/nvim-java/spring-boot.nvim";
+        rev = "218c0c26c14d99feca778e4d13f5ec3e8b1b60f0";
+      })
+      "spring-boot-nvim";
+
   # Make sure we use the pinned nixpkgs instance for wrapNeovimUnstable,
   # otherwise it could have an incompatible signature when applying this overlay.
   pkgs-wrapNeovim = inputs.nixpkgs.legacyPackages.${pkgs.system};
@@ -131,6 +139,7 @@ with final.pkgs.lib; let
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
     { plugin = nvim-java; } # Java language support
+    { plugin = spring-boot-nvim; } # Spring Boot tools for nvim-java
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -12,14 +12,6 @@ with final.pkgs.lib; let
 
   eldritch-nvim = mkNvimPlugin inputs.eldritch-nvim "eldritch-nvim";
 
-  spring-boot-nvim =
-    mkNvimPlugin
-      (builtins.fetchGit {
-        url = "https://github.com/nvim-java/spring-boot.nvim";
-        rev = "218c0c26c14d99feca778e4d13f5ec3e8b1b60f0";
-      })
-      "spring-boot-nvim";
-
   # Make sure we use the pinned nixpkgs instance for wrapNeovimUnstable,
   # otherwise it could have an incompatible signature when applying this overlay.
   pkgs-wrapNeovim = inputs.nixpkgs.legacyPackages.${pkgs.system};
@@ -139,7 +131,6 @@ with final.pkgs.lib; let
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
     { plugin = nvim-java; } # Java language support
-    { plugin = spring-boot-nvim; } # Spring Boot tools for nvim-java
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -131,115 +131,19 @@ require("lspconfig").sqls.setup({
 	capabilities = general_capabilities,
 })
 
+
 require("lspconfig").rust_analyzer.setup({
-	on_attach = general_on_attach,
-	capabilities = general_capabilities,
+        on_attach = general_on_attach,
+        capabilities = general_capabilities,
 })
 
--- jdtls + Lombok setup for Neovim (multi-module Maven via aggregator POM)
-local home = os.getenv("HOME")
-local jdtls = require("jdtls")
-local fmt = string.format
-
--- Paths & JDK installations
-local lombok = home .. "/nixos/dotfiles/lombok-1.18.38.jar"
--- local jakarta_annotation = home .. "/nixos/dotfiles/jakarta.annotation-api-1.3.5.jar"
-local javax_annotation = home .. "/nixos/dotfiles/javax.annotation-api-1.3.2.jar"
-local jdk11 = "/nix/store/lvrsn84nvwv9q4ji28ygchhvra7rsfwv-openjdk-11.0.19+7/lib/openjdk"
-local jdk21 = "/nix/store/55qm2mvhmv7n2n6yzym1idrvnlwia73z-openjdk-21.0.5+11/lib/openjdk"
-
--- Define the bundles
-local bundles = {
-	javax_annotation,
-}
-
--- Determine project root: prefer aggregator POM, fallback to Git
-local root_dir = jdtls.setup.find_root({ "pom.xml", ".git" })
-if not root_dir then
-	return
-end
-
--- Workspace directory for Eclipse data
-local project_name = vim.fn.fnamemodify(root_dir, ":t")
-local workspace_dir = home .. "/.local/share/eclipse/" .. project_name
-
--- Use JDK21 to run JDTLS with proper module setup
-local cmd = {
-	"jdtls",
-	fmt("--jvm-arg=-Dosgi.java.home=%s", jdk21),
-	"--jvm-arg=--add-opens=java.base/java.lang=ALL-UNNAMED",
-	"--jvm-arg=--add-opens=java.base/java.util=ALL-UNNAMED",
-	fmt("--jvm-arg=-javaagent:%s", lombok),
-	"--jvm-arg=-Djdt.ls.lombokSupport=true",
-	"-data",
-	workspace_dir,
-}
-
--- LSP configuration for Java
-local config = {
-	cmd = cmd,
-	root_dir = root_dir,
-	init_options = { bundles = bundles },
-	settings = {
-		java = {
-			home = jdk21,
-			import = {
-				enabled = true,
-				maven = {
-					downloadSources = true,
-					downloadJavadoc = true,
-				},
-			},
-			autoBuild = {
-				enabled = true,
-			},
-			configuration = {
-				compiler = {
-					apt = {
-						enabled = true,
-						options = { "-Xlint:-processing" },
-					},
-					annotationProcessing = {
-						enabled = true,
-						args = { "-proc:none" },
-					},
-				},
-				updateBuildConfiguration = "interactive",
-				runtimes = {
-					{ name = "JavaSE-11", path = jdk11 },
-					{ name = "JavaSE-21", path = jdk21 },
-				},
-				checkProjectCompliance = false,
-			},
-			project = { referencedLibraries = { lombok, javax_annotation } },
-			annotationProcessing = {
-				enabled = true,
-				factoryPath = { lombok },
-				generatedSourcesOutputDirectory = "target/generated-sources/annotations",
-			},
-		},
-	},
-	on_attach = general_on_attach,
-	capabilities = general_capabilities,
-}
-
--- Auto-start or attach JDTLS for Java files
-vim.api.nvim_create_autocmd("FileType", {
-	pattern = "java",
-	callback = function()
-		-- Ensure this only runs once per buffer
-		local bufnr = vim.api.nvim_get_current_buf()
-		if vim.b[bufnr].jdtls_attached then
-			return
-		end
-		vim.b[bufnr].jdtls_attached = true
-
-		-- Check if we're inside a valid project
-		if not config.root_dir then
-			vim.notify("No project root found for JDTLS", vim.log.levels.WARN)
-			return
-		end
-
-		require("jdtls").start_or_attach(config)
-	end,
+-- Java support via nvim-java with Lombok
+require("java").setup({
+        lombok = {
+                version = "nightly",
+        },
+})
+require("lspconfig").jdtls.setup({
+        on_attach = general_on_attach,
+        capabilities = general_capabilities,
 })

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -137,13 +137,9 @@ require("lspconfig").rust_analyzer.setup({
         capabilities = general_capabilities,
 })
 
--- Java support via nvim-java with Lombok and Spring Boot
+-- Java support via nvim-java with Lombok
 require("java").setup({
         lombok = {
                 version = "nightly",
         },
-        spring_boot_tools = {
-                enable = true,
-        },
 })
-require("spring_boot").setup()

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -137,13 +137,13 @@ require("lspconfig").rust_analyzer.setup({
         capabilities = general_capabilities,
 })
 
--- Java support via nvim-java with Lombok
-  require("java").setup({
-          lombok = {
-                  version = "nightly",
-          },
-  })
-require("lspconfig").jdtls.setup({
-        on_attach = general_on_attach,
-        capabilities = general_capabilities,
+-- Java support via nvim-java with Lombok and Spring Boot
+require("java").setup({
+        lombok = {
+                version = "nightly",
+        },
+        spring_boot_tools = {
+                enable = true,
+        },
 })
+require("spring_boot").setup()

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -137,14 +137,10 @@ require("lspconfig").rust_analyzer.setup({
         capabilities = general_capabilities,
 })
 
--- Java support via nvim-java with Lombok and Spring Boot tools
+-- Java support via nvim-java with Lombok
   require("java").setup({
           lombok = {
                   version = "nightly",
-          },
-          spring_boot_tools = {
-                  enable = true,
-                  version = "1.55.1",
           },
   })
 require("lspconfig").jdtls.setup({

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -137,12 +137,16 @@ require("lspconfig").rust_analyzer.setup({
         capabilities = general_capabilities,
 })
 
--- Java support via nvim-java with Lombok
-require("java").setup({
-        lombok = {
-                version = "nightly",
-        },
-})
+-- Java support via nvim-java with Lombok and Spring Boot tools
+  require("java").setup({
+          lombok = {
+                  version = "nightly",
+          },
+          spring_boot_tools = {
+                  enable = true,
+                  version = "1.55.1",
+          },
+  })
 require("lspconfig").jdtls.setup({
         on_attach = general_on_attach,
         capabilities = general_capabilities,


### PR DESCRIPTION
## Summary
- switch Neovim Java support from nvim-jdtls to nvim-java
- setup nvim-java with Lombok and minimal jdtls config
- remove obsolete jdtls instructions from README

## Testing
- `nix flake check` *(fails: command not found)*
- `luacheck nvim/plugin/lsp.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba573a58508329bcb91a45f9a5867e