### PR TITLE
feat(nvim): replace jdtls with nvim-java

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,9 @@
 
 This setup uses [nvim-java](https://github.com/nvim-java/nvim-java) for Java
 support with Lombok. Spring Boot tooling is disabled by default to avoid
-missing module errors on NixOS.
+missing module errors on NixOS. The language server uses the system JDK rather
+than downloading one, so make sure `JAVA_HOME` points to a Nix-provided JDK.
+Project sources default to the Java 11 runtime via `JAVA_HOME11`.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,7 @@
-#
-#run the following script
-#
-#cp -r /nix/store/301k2jhjanl6rr96b9yy9qzcrhjbwgmz-jdt-language-server-1.36.0/share/java/jdtls/config_linux /home/hubert/.jdtls_config
-#chmod -R u+w /home/hubert/.jdtls_config
+# NixOS Configuration
 
-
+This setup uses [nvim-java](https://github.com/nvim-java/nvim-java) for Java
+support with Lombok.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,8 @@
 # NixOS Configuration
 
 This setup uses [nvim-java](https://github.com/nvim-java/nvim-java) for Java
-support with Lombok.
+support with Lombok. Spring Boot tooling is disabled by default to avoid
+missing module errors on NixOS.
 
 #rebuilds the the whole config including main configuration for ( work/home)
 sudo nixos-rebuild switch --flake .#home --show-trace

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -130,7 +130,7 @@ with final.pkgs.lib; let
       plugin = typescript-tools-nvim; # Enhanced TypeScript support
       config = "lua << EOF\nrequire(\"typescript-tools\").setup({})\nEOF\n";
     }
-    nvim-jdtls # Java language server
+    nvim-java # Java support and tools
     {
       plugin = fidget-nvim; # LSP progress indicator
       config = "lua << EOF\nrequire(\"fidget\").setup()\nEOF\n";

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -138,6 +138,8 @@ require("lspconfig").rust_analyzer.setup({
 
 -- Java setup using nvim-java with Lombok support
 require("java").setup({
+        -- use Nix-provided JDK instead of downloading one via mason
+        jdk = { auto_install = false },
         lombok = { version = "1.18.38" },
         -- spring_boot tools require an extra plugin that isn't packaged in this
         -- Nix setup. Disable it to avoid missing module errors during startup.
@@ -149,7 +151,24 @@ require("java").setup({
         },
 })
 
+local java_home = vim.env.JAVA_HOME
+local java_home11 = vim.env.JAVA_HOME11
+
 require("lspconfig").jdtls.setup({
         on_attach = general_on_attach,
         capabilities = general_capabilities,
+        cmd_env = { JAVA_HOME = java_home },
+        settings = {
+                java = {
+                        configuration = {
+                                runtimes = {
+                                        {
+                                                name = "JavaSE-11",
+                                                path = java_home11,
+                                                default = true,
+                                        },
+                                },
+                        },
+                },
+        },
 })

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -132,114 +132,16 @@ require("lspconfig").sqls.setup({
 })
 
 require("lspconfig").rust_analyzer.setup({
-	on_attach = general_on_attach,
-	capabilities = general_capabilities,
+        on_attach = general_on_attach,
+        capabilities = general_capabilities,
 })
 
--- jdtls + Lombok setup for Neovim (multi-module Maven via aggregator POM)
-local home = os.getenv("HOME")
-local jdtls = require("jdtls")
-local fmt = string.format
+-- Java setup using nvim-java with Lombok support
+require("java").setup({
+        lombok = { version = "1.18.38" },
+})
 
--- Paths & JDK installations
-local lombok = home .. "/nixos/dotfiles/lombok-1.18.38.jar"
--- local jakarta_annotation = home .. "/nixos/dotfiles/jakarta.annotation-api-1.3.5.jar"
-local javax_annotation = home .. "/nixos/dotfiles/javax.annotation-api-1.3.2.jar"
-local jdk11 = "/nix/store/lvrsn84nvwv9q4ji28ygchhvra7rsfwv-openjdk-11.0.19+7/lib/openjdk"
-local jdk21 = "/nix/store/55qm2mvhmv7n2n6yzym1idrvnlwia73z-openjdk-21.0.5+11/lib/openjdk"
-
--- Define the bundles
-local bundles = {
-	javax_annotation,
-}
-
--- Determine project root: prefer aggregator POM, fallback to Git
-local root_dir = jdtls.setup.find_root({ "pom.xml", ".git" })
-if not root_dir then
-	return
-end
-
--- Workspace directory for Eclipse data
-local project_name = vim.fn.fnamemodify(root_dir, ":t")
-local workspace_dir = home .. "/.local/share/eclipse/" .. project_name
-
--- Use JDK21 to run JDTLS with proper module setup
-local cmd = {
-	"jdtls",
-	fmt("--jvm-arg=-Dosgi.java.home=%s", jdk21),
-	"--jvm-arg=--add-opens=java.base/java.lang=ALL-UNNAMED",
-	"--jvm-arg=--add-opens=java.base/java.util=ALL-UNNAMED",
-	fmt("--jvm-arg=-javaagent:%s", lombok),
-	"--jvm-arg=-Djdt.ls.lombokSupport=true",
-	"-data",
-	workspace_dir,
-}
-
--- LSP configuration for Java
-local config = {
-	cmd = cmd,
-	root_dir = root_dir,
-	init_options = { bundles = bundles },
-	settings = {
-		java = {
-			home = jdk21,
-			import = {
-				enabled = true,
-				maven = {
-					downloadSources = true,
-					downloadJavadoc = true,
-				},
-			},
-			autoBuild = {
-				enabled = true,
-			},
-			configuration = {
-				compiler = {
-					apt = {
-						enabled = true,
-						options = { "-Xlint:-processing" },
-					},
-					annotationProcessing = {
-						enabled = true,
-						args = { "-proc:none" },
-					},
-				},
-				updateBuildConfiguration = "interactive",
-				runtimes = {
-					{ name = "JavaSE-11", path = jdk11 },
-					{ name = "JavaSE-21", path = jdk21 },
-				},
-				checkProjectCompliance = false,
-			},
-			project = { referencedLibraries = { lombok, javax_annotation } },
-			annotationProcessing = {
-				enabled = true,
-				factoryPath = { lombok },
-				generatedSourcesOutputDirectory = "target/generated-sources/annotations",
-			},
-		},
-	},
-	on_attach = general_on_attach,
-	capabilities = general_capabilities,
-}
-
--- Auto-start or attach JDTLS for Java files
-vim.api.nvim_create_autocmd("FileType", {
-	pattern = "java",
-	callback = function()
-		-- Ensure this only runs once per buffer
-		local bufnr = vim.api.nvim_get_current_buf()
-		if vim.b[bufnr].jdtls_attached then
-			return
-		end
-		vim.b[bufnr].jdtls_attached = true
-
-		-- Check if we're inside a valid project
-		if not config.root_dir then
-			vim.notify("No project root found for JDTLS", vim.log.levels.WARN)
-			return
-		end
-
-		require("jdtls").start_or_attach(config)
-	end,
+require("lspconfig").jdtls.setup({
+        on_attach = general_on_attach,
+        capabilities = general_capabilities,
 })

--- a/nvim/plugin/lsp.lua
+++ b/nvim/plugin/lsp.lua
@@ -139,6 +139,14 @@ require("lspconfig").rust_analyzer.setup({
 -- Java setup using nvim-java with Lombok support
 require("java").setup({
         lombok = { version = "1.18.38" },
+        -- spring_boot tools require an extra plugin that isn't packaged in this
+        -- Nix setup. Disable it to avoid missing module errors during startup.
+        spring_boot_tools = { enable = false },
+        mason = {
+                registries = {
+                        "github:nvim-java/mason-registry",
+                },
+        },
 })
 
 require("lspconfig").jdtls.setup({


### PR DESCRIPTION
## Summary
- switch Neovim Java support from nvim-jdtls to nvim-java
- simplify LSP config and enable Lombok via nvim-java
- clean up README references to jdtls

## Testing
- `bash build.sh` *(fails: nix: command not found)*
- `sh <(curl -L https://nixos.org/nix/install)` *(fails: the group 'nixbld' does not exist)*
- `apt-get install -y neovim` *(fails: Package neovim has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68ba658cb948832984efba24ac33cfe6